### PR TITLE
Use unicodecsv to replace csv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
   - "3.3"
 # command to install dependencies
 install:
-  - "make build"
+  - "make setup"
 # command to run tests
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
   - "3.3"
 # command to install dependencies
 install:
-  - "pip install -r requirements.txt"
+  - "make build"
 # command to run tests
 script: nosetests

--- a/jay/__init__.py
+++ b/jay/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import os
 import sys
+import csv
 import io
 from os.path import join
 from docopt import docopt
@@ -58,7 +59,7 @@ class Jay(object):
             with io.open(self.idx, 'r') as f:
                 # get each row from index,
                 # where each csv row is [dir, access_timestamp]
-                self.idx_rows = {d: ts for d, ts in reader(f)}
+                self.idx_rows = {d: ts for d, ts in csv.reader(f)}
         except:
             raise Exception("jay: an error ocurred while opening the index {}.".format(self.idx))
 
@@ -89,7 +90,7 @@ class Jay(object):
                 # save the most recent dirs only
                 rows = [tup for tup in self.idx_rows.items()]
                 rows = sorted(rows, key=lambda x: x[1], reverse=True)
-                writer(f, rows[:self.idx_max_size])
+                csv.writer(f).writerows(rows[:self.idx_max_size])
         except Exception as e:
             raise Exception("jay: an error ocurred while opening the index {}.".format(e))
 
@@ -246,17 +247,6 @@ def out(d):
        Helps mocking for tests, and maybe in the future
        this could be used to provide other forms of output"""
     print(d)
-
-
-def reader(f):
-    d = f.read().splitlines()
-    for line in d:
-        yield line.split(',')
-
-
-def writer(f, rows):
-    for row in rows:
-        f.write(str(row) + '\n')
 
 
 def main():

--- a/jay/__init__.py
+++ b/jay/__init__.py
@@ -88,14 +88,11 @@ class Jay(object):
 
     def dump(self):
         """Dump the dirs to the index file"""
-        try:
-            with io.open(self.idx, WRITE_MODE) as f:
-                # save the most recent dirs only
-                rows = [tup for tup in self.idx_rows.items()]
-                rows = sorted(rows, key=lambda x: x[1], reverse=True)
-                csv.writer(f).writerows(rows[:self.idx_max_size])
-        except Exception as e:
-            raise Exception("jay: an error ocurred while opening the index {}.".format(e))
+        with io.open(self.idx, WRITE_MODE) as f:
+            # save the most recent dirs only
+            rows = [tup for tup in self.idx_rows.items()]
+            rows = sorted(rows, key=lambda x: x[1], reverse=True)
+            csv.writer(f).writerows(rows[:self.idx_max_size])
 
     @property
     def recent_dir(self):

--- a/jay/__init__.py
+++ b/jay/__init__.py
@@ -1,13 +1,17 @@
 from __future__ import unicode_literals
 import os
 import sys
-import csv
 import io
 from os.path import join
 from docopt import docopt
 from fuzzywuzzy import process
 from xdg import BaseDirectory
 from time import time
+import csv
+
+
+if sys.version_info.major < 3:
+    import unicodecsv as csv
 
 
 __doc__ = """
@@ -28,6 +32,8 @@ JAY_XDG_DATA_HOME = BaseDirectory.save_data_path('jay')
 RECENT_IDX_FILENAME = join(JAY_XDG_DATA_HOME, 'recent')
 IDX_FILENAME = join(JAY_XDG_DATA_HOME, 'index')  # index filename
 IDX_MAX_SIZE = 100  # max number of entries in the index
+READ_MODE = 'rb' if sys.version_info.major < 3 else 'r'
+WRITE_MODE = 'wb' if sys.version_info.major < 3 else 'w'
 
 
 class Jay(object):
@@ -83,10 +89,7 @@ class Jay(object):
     def dump(self):
         """Dump the dirs to the index file"""
         try:
-            mode = 'w'
-            if sys.version_info.major < 3:
-                mode += 'b'
-            with io.open(self.idx, mode) as f:
+            with io.open(self.idx, WRITE_MODE) as f:
                 # save the most recent dirs only
                 rows = [tup for tup in self.idx_rows.items()]
                 rows = sorted(rows, key=lambda x: x[1], reverse=True)
@@ -111,10 +114,7 @@ class Jay(object):
     def update_recent_dir(self):
         """Write the cwd to the RECENT_DIR_IDX file"""
         try:
-            mode = 'w'
-            if sys.version_info.major < 3:
-                mode += 'b'
-            with io.open(self.recent_idx, mode) as f:
+            with io.open(self.recent_idx, WRITE_MODE) as f:
                 f.writelines([os.getcwd()])
         except:
             raise Exception("jay: an error ocurred while opening the recent index {}.".format(self.recent_idx))

--- a/makefile
+++ b/makefile
@@ -4,4 +4,8 @@ build:
 uninstall:
 	pip uninstall -y jay
 
+requirements:
+	pip install -r requirements.txt
+
 rebuild: uninstall build
+setup: requirements build

--- a/makefile
+++ b/makefile
@@ -1,7 +1,5 @@
-VERSION=$(shell echo `python jay/__init__.py --version`)
-
 build:
-	python setup.py sdist && pip install dist/jay-$(VERSION).tar.gz
+	python setup.py sdist && pip install dist/jay-0.1.tar.gz
 
 uninstall:
 	pip uninstall -y jay

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,1 @@
+unicodecsv==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 docopt==0.6.1
 git+git://github.com/seatgeek/fuzzywuzzy.git#egg=fuzzywuzzy
 pyxdg==0.25
-unicodecsv==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 docopt==0.6.1
 git+git://github.com/seatgeek/fuzzywuzzy.git#egg=fuzzywuzzy
 pyxdg==0.25
+unicodecsv==0.9.4

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
+import sys
 from distutils.core import setup
 
+
 requires = ['docopt', 'fuzzywuzzy', 'pyxdg']
+if sys.version_info.major < 3:
+    requires += ['unicodecsv']  # use only in python2.x
+
 
 setup(
     name='jay',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import os
 import sys
@@ -188,6 +189,21 @@ def test_dump():
     """Dump method should persist idx_rows"""
     mkdir('')
     d = '/test/dir'
+    update_time = '1387159989.41'
+    expected_output = '{0},{1}'.format(d, update_time)
+
+    j = Jay(idx_filename=TEST_IDX_FILENAME,
+            recent_idx_filename=TEST_RECENT_IDX_FILENAME)
+    j.idx_rows = {d: update_time}
+    j.dump()
+    assert io.open(TEST_IDX_FILENAME).read().strip() == expected_output
+
+
+@with_setup(teardown=teardown_both_idx)
+def test_dump_unicode_support():
+    """Dump method should persist idx_rows"""
+    mkdir('')
+    d = '/test/éñ'
     update_time = '1387159989.41'
     expected_output = '{0},{1}'.format(d, update_time)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,7 +9,7 @@ import shutil
 from docopt import docopt
 sys.path.insert(0, os.path.abspath('..'))
 from jay import Jay, run, __doc__, relative_of_cwd, walkdir, listdir
-from nose.tools import with_setup
+from nose.tools import with_setup, eq_
 
 
 TEST_DIR = os.path.join('tests', os.path.abspath(os.path.dirname(__file__)), 'testdirs')
@@ -77,7 +77,7 @@ def test_empty_idx_content_is_loaded_from_file():
     expected_rows = {}
     mkdir('')
     j = Jay(idx_filename=TEST_IDX_FILENAME)
-    assert j.idx_rows == expected_rows
+    eq_(j.idx_rows, expected_rows)
 
 
 @with_setup(setup=setup_idx, teardown=teardown_both_idx)
@@ -86,7 +86,7 @@ def test_idx_content_is_loaded_from_file():
     expected_rows = {'/tmp/dir1': '1387159989.41',
                      '/home/dir2': '1387158735.64'}
     j = Jay(idx_filename=TEST_IDX_FILENAME)
-    assert j.idx_rows == expected_rows
+    eq_(j.idx_rows, expected_rows)
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -108,7 +108,7 @@ def test_dump_max_num_entries():
             idx_max_size=TEST_IDX_MAX_SIZE)
     j.idx_rows = {d1: update_time1, d2: update_time2, d3: update_time3}
     j.dump()
-    assert io.open(TEST_IDX_FILENAME).readlines() == expected_output
+    eq_(io.open(TEST_IDX_FILENAME).readlines(), expected_output)
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -135,7 +135,7 @@ def test_update_with_existing_directory():
 
     _update(j, d, update_time='1387159989.41')
     _update(j, d, future_time)
-    assert j.idx_rows == {d: future_time}
+    eq_(j.idx_rows, {d: future_time})
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -149,7 +149,7 @@ def test_delete_with_existing_directory():
     _update(j, d, update_time)
 
     j.delete(d)
-    assert j.idx_rows == {}
+    eq_(j.idx_rows, {})
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -160,7 +160,7 @@ def test_delete_with_non_existing_directory():
     assert not os.path.isfile(TEST_IDX_FILENAME)
     j = Jay(idx_filename=TEST_IDX_FILENAME)
     j.delete('/non/existent/dir')
-    assert j.idx_rows == {}
+    eq_(j.idx_rows, {})
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -172,7 +172,7 @@ def test_updates_are_persisted():
     j = Jay(idx_filename=TEST_IDX_FILENAME)
     _update(j, d, update_time)
     expected_output = '{0},{1}'.format(d, update_time)
-    assert io.open(TEST_IDX_FILENAME).read().strip() == expected_output
+    eq_(io.open(TEST_IDX_FILENAME).read().strip(), expected_output)
 
 
 @with_setup(setup=setup_idx, teardown=teardown_both_idx)
@@ -181,7 +181,7 @@ def test_deletions_are_persisted():
     j = Jay(idx_filename=TEST_IDX_FILENAME)
     j.delete('/tmp/dir1')  # delete an existent entry
     expected_output = '/home/dir2,1387158735.64' # the other entry
-    assert io.open(TEST_IDX_FILENAME).read().strip() == expected_output
+    eq_(io.open(TEST_IDX_FILENAME).read().strip(), expected_output)
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -196,7 +196,7 @@ def test_dump():
             recent_idx_filename=TEST_RECENT_IDX_FILENAME)
     j.idx_rows = {d: update_time}
     j.dump()
-    assert io.open(TEST_IDX_FILENAME).read().strip() == expected_output
+    eq_(io.open(TEST_IDX_FILENAME).read().strip(), expected_output)
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -225,7 +225,7 @@ def test_recent_dir():
 
     j = Jay(idx_filename=TEST_IDX_FILENAME,
             recent_idx_filename=TEST_RECENT_IDX_FILENAME)
-    assert j.recent_dir == '/dumb/dir1'
+    eq_(j.recent_dir, '/dumb/dir1')
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -236,7 +236,7 @@ def test_nonexistant_recent_dir():
     assert not os.path.isfile(TEST_RECENT_IDX_FILENAME)
     j = Jay(idx_filename=TEST_IDX_FILENAME,
             recent_idx_filename=TEST_RECENT_IDX_FILENAME)
-    assert j.recent_dir == ''
+    eq_(j.recent_dir, '')
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -251,7 +251,7 @@ def test_empty_recent_dir():
 
     j = Jay(idx_filename=TEST_IDX_FILENAME,
             recent_idx_filename=TEST_RECENT_IDX_FILENAME)
-    assert j.recent_dir == ''
+    eq_(j.recent_dir, '')
 
 
 @with_setup(teardown=teardown_both_idx)
@@ -276,7 +276,7 @@ def test_relative_of_cwd_with_one_dot():
     mkdir('')
     with mock.patch.object(os, 'getcwd', return_value=TEST_DIR):
         result = relative_of_cwd('.')
-    assert TEST_DIR == result
+    eq_(TEST_DIR, result)
 
 
 @with_setup(teardown=teardown_dirs)
@@ -298,7 +298,7 @@ def test_relative_of_cwd_with_one_dot_and_one_dotted_child():
     mkdir('.dir')
     with mock.patch.object(os, 'getcwd', return_value=TEST_DIR):
         result = relative_of_cwd('.')
-    assert result == TEST_DIR
+    eq_(result, TEST_DIR)
 
 
 @with_setup(teardown=teardown_dirs)
@@ -309,7 +309,7 @@ def test_relative_of_cwd_with_two_dots_and_two_dotted_child():
     cwd = os.path.join(TEST_DIR, 'dir')  # im in TEST_DIR/dir/
     with mock.patch.object(os, 'getcwd', return_value=cwd):
         result = relative_of_cwd('..')
-    assert result == TEST_DIR
+    eq_(result, TEST_DIR)
 
 
 @with_setup(teardown=teardown_dirs)
@@ -320,7 +320,7 @@ def test_relative_of_cwd_with_three_dots_and_three_dotted_child():
     cwd = os.path.join(TEST_DIR, 'dir', 'dir2')  # im in TEST_DIR/dir/dir2/
     with mock.patch.object(os, 'getcwd', return_value=cwd):
         result = relative_of_cwd('...')
-    assert result == TEST_DIR
+    eq_(result, TEST_DIR)
 
 
 @with_setup(teardown=teardown_dirs)
@@ -331,7 +331,7 @@ def test_relative_of_cwd_with_two_dots():
     two_level_deep_dir = os.path.join(TEST_DIR, 'dir1', 'dir2')
     with mock.patch.object(os, 'getcwd', return_value=two_level_deep_dir):
         result = relative_of_cwd('..')
-    assert one_level_deep_dir == result
+    eq_(one_level_deep_dir, result)
 
 
 @with_setup(teardown=teardown_dirs)
@@ -354,7 +354,7 @@ def test_relative_of_cwd_with_three_dots():
     two_level_deep_dir = os.path.join(TEST_DIR, 'dir1', 'dir2')
     with mock.patch.object(os, 'getcwd', return_value=two_level_deep_dir):
         result = relative_of_cwd('...')
-    assert TEST_DIR == result
+    eq_(result, TEST_DIR)
 
 
 @with_setup(teardown=teardown_dirs)
@@ -375,21 +375,21 @@ def test_listdir_returns_dirs_only():
     """listdir function should returns child directories only"""
     mkdir('dir')
     touch('file')
-    assert ['dir'] == listdir(TEST_DIR)
+    eq_(['dir'], listdir(TEST_DIR))
 
 
 @with_setup(teardown=teardown_dirs)
 def test_listdir_returns_a_sorted_list_of_child_dirs():
     """listdir function should return a sorted list of child directories"""
     mkdir('dir1', 'dir2')
-    assert ['dir1', 'dir2'] == listdir(TEST_DIR)
+    eq_(['dir1', 'dir2'], listdir(TEST_DIR))
 
 
 @with_setup(teardown=teardown_dirs)
 def test_walkdir_without_terms():
     """Calling walkdir without terms should return the rootdir"""
     mkdir('')  # just rootdir
-    assert TEST_DIR == walkdir(TEST_DIR, terms=[])
+    eq_(TEST_DIR, walkdir(TEST_DIR, terms=[]))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -398,7 +398,7 @@ def test_walkdir_without_one_existing_dir_returns_rootdir():
     mkdir('')  # just rootdir
     assert not os.path.isdir(os.path.join(TEST_DIR, 'fake_dir'))
     expected_result = os.path.join(TEST_DIR, '')
-    assert expected_result == walkdir(TEST_DIR, terms=['fake_dir'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['fake_dir']))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -407,7 +407,7 @@ def test_walkdir_without_existings_dirs_returns_rootdir():
     mkdir('')  # just rootdir
     assert not os.path.isdir(os.path.join(TEST_DIR, 'fake_dir1', 'fake_dir2'))
     expected_result = os.path.join(TEST_DIR, '')
-    assert expected_result == walkdir(TEST_DIR, terms=['fake_dir2', 'fake_dir1'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['fake_dir2', 'fake_dir1']))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -415,7 +415,7 @@ def test_walkdir_with_fuzzy_names():
     """Walkdir should support fuzzy finding for child dirs"""
     mkdir('dir1/filedir', 'dir1/filedir2')
     expected_result = os.path.join(TEST_DIR, 'dir1', 'filedir')
-    assert expected_result == walkdir(TEST_DIR, terms=['dir', 'dir'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['dir', 'dir']))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -424,7 +424,7 @@ def test_walkdir_with_fuzzy_names_in_different_parts_of_the_dirname():
        fuzzy finding for child dirs"""
     mkdir('dir1/filedir', 'dir1/dir', 'dir1/dir1')
     expected_result = os.path.join(TEST_DIR, 'dir1', 'dir')
-    assert expected_result == walkdir(TEST_DIR, terms=['dir', 'dir'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['dir', 'dir']))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -432,7 +432,7 @@ def test_walkdir_with_one_existing_dir():
     """Calling walkdir with one existing dir as terms should return that dir"""
     mkdir('dir1')
     expected_result = os.path.join(TEST_DIR, 'dir1')
-    assert expected_result == walkdir(TEST_DIR, terms=['dir1'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['dir1']))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -441,7 +441,7 @@ def test_walkdir_without_two_existing_dirs_and_one_fake_subdir():
     mkdir('dir1/dir2')
     assert not os.path.isdir(os.path.join(TEST_DIR, 'dir1', 'dir2', 'fake_dir'))
     expected_result = os.path.join(TEST_DIR, 'dir1', 'dir2', '')
-    assert expected_result == walkdir(TEST_DIR, terms=['fake_dir', 'dir2', 'dir1'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['fake_dir', 'dir2', 'dir1']))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -450,7 +450,7 @@ def test_walkdir_with_a_filename():
     mkdir('dir1')
     touch('dir1/file1')
     expected_result = os.path.join(TEST_DIR, 'dir1', '')
-    assert expected_result == walkdir(TEST_DIR, terms=['file1', 'dir1'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['file1', 'dir1']))
 
 
 @with_setup(teardown=teardown_dirs)
@@ -459,4 +459,4 @@ def test_walkdir_with_ambiguous_terms():
     mkdir('dir1/filedir', 'dir1/filedir2')
     touch('dir1/file1')  # caution a file!
     expected_result = os.path.join(TEST_DIR, 'dir1', 'filedir')
-    assert expected_result == walkdir(TEST_DIR, terms=['file', 'dir1'])
+    eq_(expected_result, walkdir(TEST_DIR, terms=['file', 'dir1']))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -229,6 +229,20 @@ def test_recent_dir():
 
 
 @with_setup(teardown=teardown_both_idx)
+def test_recent_dir_unicode_support():
+    """Jay.recent_dir should return the first line
+       in recent idx file"""
+    mkdir('')
+    with io.open(TEST_RECENT_IDX_FILENAME, 'w') as f:
+        f.write('/dumb/dir1éñö\n')
+        f.write('/dumb/dir2éñö')
+
+    j = Jay(idx_filename=TEST_IDX_FILENAME,
+            recent_idx_filename=TEST_RECENT_IDX_FILENAME)
+    eq_(j.recent_dir, '/dumb/dir1éñö')
+
+
+@with_setup(teardown=teardown_both_idx)
 def test_nonexistant_recent_dir():
     """Jay.recent_dir should return an empty string
        if the recent idx file is empty"""
@@ -451,6 +465,15 @@ def test_walkdir_with_a_filename():
     touch('dir1/file1')
     expected_result = os.path.join(TEST_DIR, 'dir1', '')
     eq_(expected_result, walkdir(TEST_DIR, terms=['file1', 'dir1']))
+
+
+@with_setup(teardown=teardown_dirs)
+def test_walkdir_with_a_filename_unicode_support():
+    """Walkdir should return the path until the last dir that exists"""
+    mkdir('dir1éñö')
+    touch('dir1éñö/file1')
+    expected_result = os.path.join(TEST_DIR, 'dir1éñö', '')
+    eq_(expected_result, walkdir(TEST_DIR, terms=['file1', 'dir1éñö']))
 
 
 @with_setup(teardown=teardown_dirs)


### PR DESCRIPTION
Use unicodecsv in python 2.x and csv in python 3 to support non-ascii directory names.
